### PR TITLE
Issues with host including port, protocol check

### DIFF
--- a/src/qbt.js
+++ b/src/qbt.js
@@ -532,6 +532,13 @@ exports.connect = async (host, username, password) => {
 				return await addPeers(options, cookie, hashes, peers)
 			},
 			/**
+			 * Add torrent
+			 * @param {string} urls - URLs of the trackers, separated by a newline `\n`
+			 */
+			addTorrent: async (urls) => {
+				return await addTorrent(options, cookie, urls)
+			},
+			/**
 			 * Add trackers to torrent
 			 * @param {string} hash - The hash of the torrent
 			 * @param {string} urls - URLs of the trackers, separated by a newline `\n`
@@ -1065,7 +1072,10 @@ async function addPeers(options, cookie, hashes, peers) {
 	return
 }
 
-// TODO: addTorrent()
+async function addTorrent(options, cookie, urls) {
+	await performRequest(options, cookie, '/torrents/add', { urls: encodeURI(urls) })
+	return
+}
 
 async function addTrackers(options, cookie, hash, urls) {
 	await performRequest(options, cookie, '/torrents/addTrackers', { hash: hash, urls: encodeURI(urls) })


### PR DESCRIPTION
I was having issues using the package and found that:

1. hostname.protocol returns http: or https: not https:// as expected in the protocol check
2. hostname.host includes the port which was causing issues when setting up headers (dns.js check was invalid)

This was causing a 401 error when trying to log in. The above fixes these and allows a login.