### PR TITLE
Update plainify regex to work with numbers

### DIFF
--- a/src/qbt.js
+++ b/src/qbt.js
@@ -1332,6 +1332,6 @@ function performRequest(opt, cookie, path, parameters) {
 function plainify(json) {
 	let str = JSON.stringify(json)
 	str = str.replace(/{([^}]*)}/g, '$1')
-	str = str.replace(/"([^"]*)":"([^"]*)",?/g, '$1=$2&')
+	str = str.replace(/"([^"]*)":"?([^",]*)"?,?/g, '$1=$2&')
 	return str
 }


### PR DESCRIPTION
I was trying to update the global speed limit on qBittorrent (`setGlobalDownloadLimit`) and got a 400 error. I did some digging and it looks like the problem is in the [RegEx](https://github.com/flowbe/node-qbittorrent-api-v2/blob/6f4e527a653a115958fe2aaa0b05ffaa225dcfcc/src/qbt.js#L1335) within the `plainify` method that converts the parameters object to key/value pairs. Right now the RegEx is looking for values within quotes:

```javascript
str = str.replace(/"([^"]*)":"([^"]*)",?/g, '$1=$2&')
```

Since the global speed limit requires a number (and therefore isn't surrounded by quotes in JSON), this doesn't get replaced and formatted and `str` winds up looking like `"limit":10240000` rather than `limit=10240000`.

This PR makes the quotes around the field value optional so that both numbers and strings get captured and formatted correctly.

[Here's](https://regex101.com/r/wSby1X/1) the old RegEx and [here's](https://regex101.com/r/XXeMr1/1) the new RegEx.