### PR TITLE
Fixed deleteTorrents, and simplified the plainify function

### DIFF
--- a/src/qbt.js
+++ b/src/qbt.js
@@ -487,10 +487,10 @@ exports.connect = async (host, username, password) => {
 			/**
 			 * Delete one or several torrents
 			 * @param {string} hashes - The hashes of the torrents you want to delete. It can contain multiple hashes separated by |, to delete multiple torrents, or set to 'all', to delete all torrents
-			 * @param {boolean} deleteFile - If set to `true`, the downloaded data will also be deleted, otherwise has no effect
+			 * @param {boolean} deleteFiles - If set to `true`, the downloaded data will also be deleted, otherwise has no effect
 			 */
-			deleteTorrents: async (hashes, deleteFile) => {
-				return await deleteTorrents(options, cookie, hashes, deleteFile)
+			deleteTorrents: async (hashes, deleteFiles) => {
+				return await deleteTorrents(options, cookie, hashes, deleteFiles)
 			},
 			/**
 			 * Recheck one or several torrents
@@ -1035,8 +1035,8 @@ async function resumeTorrents(options, cookie, hashes) {
 	return
 }
 
-async function deleteTorrents(options, cookie, hashes, deleteFile) {
-	await performRequest(options, cookie, '/torrents/delete', { hashes: hashes, deleteFile: deleteFile })
+async function deleteTorrents(options, cookie, hashes, deleteFiles) {
+	await performRequest(options, cookie, '/torrents/delete', { hashes: hashes, deleteFiles: deleteFiles })
 	return
 }
 

--- a/src/qbt.js
+++ b/src/qbt.js
@@ -1330,8 +1330,5 @@ function performRequest(opt, cookie, path, parameters) {
  * @return {string} Plain text parameters
  */
 function plainify(json) {
-	let str = JSON.stringify(json)
-	str = str.replace(/{([^}]*)}/g, '$1')
-	str = str.replace(/"([^"]*)":"([^"]*)",?/g, '$1=$2&')
-	return str
+	return Object.entries(json).map(val => val.join('=')).join('&');
 }


### PR DESCRIPTION
The PR fixes the delete torrents endpoint usage. Previously it was passing `deleteFile` where it should have been `deleteFiles` as per the docs https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#delete-torrents

I've also simplified the plainify function from more complicated than it needed to be regex to a simple string concatenation. Since we are doing a direct mapping of `key=val&key=val` from an object.