### PR TITLE
Update qbt.js line 878

### DIFF
--- a/src/qbt.js
+++ b/src/qbt.js
@@ -875,7 +875,6 @@ exports.connect = async (host, username, password) => {
 			},
 		}
 	} catch (err) {
-		console.error(err)
 		throw new Error(`Login failed with username: ${username}`)
 	}
 }


### PR DESCRIPTION
```diff
qbt.js:878
-console.error(err)
```

We should not have any console log/error in the source code. HTTP errors appear in the console even if they are catch.